### PR TITLE
Add gitlab ref to helm chart

### DIFF
--- a/deployment/templates/gitlab-secret.yaml
+++ b/deployment/templates/gitlab-secret.yaml
@@ -12,4 +12,5 @@ stringData:
   GITLAB_PERSONAL_ACCESS_TOKEN: "{{ .Values.gitLabPersonalAccessToken }}"
   ENGAGEMENTS_REPOSITORY_ID: "{{ .Values.engagementsRepositoryId }}"
   WEBHOOK_FILE: "{{ .Values.config.hookFile.path }}/{{ .Values.config.hookFile.name }}"
+  CONFIG_GITLAB_REF: "{{ .Values.gitlabRef }}"
 {{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -4,3 +4,5 @@ servicePort: 8080
 
 imageName: "quay.io/rht-labs/omp-git-api"
 imageTag: "latest" # This is intended to be overridden by the parent Helm chart.
+
+gitlabRef: "master"


### PR DESCRIPTION
This adds the ability to define the gitlab config branch via the helm chart

cc/ @mcanoy @dwasinge 