### PR TITLE
Bug Fix: Get all Pulling back Page 1 from GitLab API Twice

### DIFF
--- a/src/main/java/com/redhat/labs/omp/models/PagedResults.java
+++ b/src/main/java/com/redhat/labs/omp/models/PagedResults.java
@@ -27,18 +27,18 @@ import lombok.NoArgsConstructor;
 public class PagedResults<T> {
     public static final Logger LOGGER = LoggerFactory.getLogger(PagedResults.class);
             
-    @Builder.Default private int number = 0;
+    @Builder.Default private int number = 1;
     @Builder.Default private int total = 1;
     @Builder.Default private List<T> results = new ArrayList<>();
     
     
     public boolean hasMore() {
-        return total > number;
+        return total >= number;
     }
     
     public void update(Response response, GenericType<List<T>> type) {
         
-        if(number == 0) {
+        if(number == 1) {
             String totalPageString = response.getHeaderString("X-Total-Pages");
             total = Integer.valueOf(totalPageString);
             LOGGER.trace("TOTAL PAGES {}", total);


### PR DESCRIPTION
- changed the indexing of the GitLab Paging so that it starts with 1 instead of 0
  - the default page for the GitLab API is 1.  having 0 called retrieves the first page twice and the last page is not retrieved