### PR TITLE
GET All Engagements - Performance Improvements Part 1: Use Parallel Stream

### DIFF
--- a/src/main/java/com/redhat/labs/omp/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/omp/resource/EngagementResource.java
@@ -1,10 +1,6 @@
 package com.redhat.labs.omp.resource;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotBlank;
@@ -125,24 +121,6 @@ public class EngagementResource {
         
         Status status = engagementService.getProjectStatus(customer, engagement);
         return Response.ok().entity(status).build();
-    }
-
-    @GET
-    @Path("/count")
-    public Response getEngagementCount() {
-
-        Instant start = Instant.now();
-
-        Integer count = engagementService.countAllEngagements();
-
-        Instant end = Instant.now();
-        long elapsed = Duration.between(start, end).getSeconds();
-
-        Map<String, String> map = new HashMap<>();
-        map.put("count", count.toString());
-        map.put("elapsed_time", String.valueOf(elapsed));
-        return Response.ok(map).build();
-
     }
 
 }

--- a/src/main/java/com/redhat/labs/omp/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/omp/resource/EngagementResource.java
@@ -1,6 +1,10 @@
 package com.redhat.labs.omp.resource;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotBlank;
@@ -121,6 +125,24 @@ public class EngagementResource {
         
         Status status = engagementService.getProjectStatus(customer, engagement);
         return Response.ok().entity(status).build();
+    }
+
+    @GET
+    @Path("/count")
+    public Response getEngagementCount() {
+
+        Instant start = Instant.now();
+
+        Integer count = engagementService.countAllEngagements();
+
+        Instant end = Instant.now();
+        long elapsed = Duration.between(start, end).getSeconds();
+
+        Map<String, String> map = new HashMap<>();
+        map.put("count", count.toString());
+        map.put("elapsed_time", String.valueOf(elapsed));
+        return Response.ok(map).build();
+
     }
 
 }

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -193,12 +193,6 @@ public class EngagementService {
 
     }
 
-    public Integer countAllEngagements() {
-
-        return getAllEngagements().size();
-
-    }
-
     public Engagement getEngagement(String namespaceOrId, boolean includeStatus) {
         Engagement engagement = null;
 
@@ -223,7 +217,7 @@ public class EngagementService {
         return engagement;
     }
     
-    public Optional<Engagement> getEngagement(Project project, boolean includeStatus) {
+    private Optional<Engagement> getEngagement(Project project, boolean includeStatus) {
         Engagement engagement = null;
         
         Optional<File> engagementFile = fileService.getFileAllow404(project.getId(), ENGAGEMENT_FILE);


### PR DESCRIPTION
- uses parallel stream to improve response time

Testing performed in s44 shows that the number of engagements returned is consistent and responds in around 30 seconds for 102 engagements

```
sh-4.2$ curl http://localhost:8080/api/v1/engagements/count
{"count":"102","elapsed_time":"28"}sh-4.2$ curl http://localhost:8080/api/v1/engagements/count
{"count":"102","elapsed_time":"26"}sh-4.2$ curl http://localhost:8080/api/v1/engagements/count
{"count":"102","elapsed_time":"35"}sh-4.2$ curl http://localhost:8080/api/v1/engagements/count
{"count":"102","elapsed_time":"25"}sh-4.2$ curl http://localhost:8080/api/v1/engagements/count
{"count":"102","elapsed_time":"25"}sh-4.2$ curl http://localhost:8080/api/v1/engagements/count
{"count":"102","elapsed_time":"26"}sh-4.2$ 
```