### PR TITLE
Use Commit Message if Provided

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/models/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/Engagement.java
@@ -54,5 +54,6 @@ public class Engagement {
     private List<Category> categories;
 
     private List<Artifact> artifacts;
+    private String commitMessage;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -245,6 +245,7 @@ public class EngagementService {
         //Git api is read only here.
         engagement.setCommits(null);
         engagement.setStatus(null);
+        engagement.setCommitMessage(null);
 
         String fileContent = json.toJson(engagement);
         return File.builder().content(fileContent).filePath(ENGAGEMENT_FILE).build();

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -87,13 +87,16 @@ public class EngagementService {
         Project project = createProjectStucture(engagement);
         engagement.setProjectId(project.getId());
 
+        // get commit message before creating file
+        Optional<String> commitMessageOptional = Optional.ofNullable(engagement.getCommitMessage());
+
         // get all template files
         List<File> repoFiles = new ArrayList<>();
         repoFiles.add(createEngagmentFile(engagement));
 
         // create actions for multiple commit
         CommitMultiple commit = createCommitMultiple(repoFiles, project.getId(), DEFAULT_BRANCH, author,
-                authorEmail, project.isFirst());
+                authorEmail, project.isFirst(), commitMessageOptional);
 
         if (LOGGER.isDebugEnabled()) {
             commit.getActions().stream().forEach(file -> LOGGER.debug("Action File path :: {}", file.getFilePath()));
@@ -312,15 +315,17 @@ public class EngagementService {
     }
 
     private CommitMultiple createCommitMultiple(List<File> filesToCommit, Integer projectId, String branch,
-            String authorName, String authorEmail, boolean isNew) {
+            String authorName, String authorEmail, boolean isNew, Optional<String> commitMessageOptional) {
 
         List<Action> actions = new ArrayList<>();
 
         // convert each file to action - parallelStream was bringing inconsistent
         // results
         filesToCommit.stream().forEach(file -> actions.add(createAction(file, isNew)));
-        
-        String commitMessage = isNew ? commitMessage("Engagement created") : commitMessage("Engagement updated");
+
+        // use message if provided.  otherwise, defaults
+        String commitMessage = commitMessageOptional
+                .orElse(isNew ? commitMessage("Engagement created") : commitMessage("Engagement updated"));
 
         return CommitMultiple.builder().id(projectId).branch(branch).commitMessage(commitMessage).actions(actions)
                 .authorName(authorName).authorEmail(authorEmail).build();


### PR DESCRIPTION
- the value of the `commit_message` attribute will be used as the commit message when provided.  otherwise, the default commit messages will be used.