### PR TITLE
Allow Customer and/or Project Name change

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -46,9 +46,11 @@ public class EngagementResource {
     @Timed(name = "performedCreates", description = "How much time it takes to create an engagement", unit = MetricUnits.MILLISECONDS)
     public Response createEngagement(Engagement engagement, @Context UriInfo uriInfo,
             @NotBlank @QueryParam("username") String author, @NotBlank @QueryParam("userEmail") String authorEmail,
-            @QueryParam("newCustomerName") Optional<String> newCustomerName, @QueryParam("newProjectName") Optional<String> newProjectName) {
+            @QueryParam("previousCustomerName") Optional<String> previousCustomerName,
+            @QueryParam("previousProjectName") Optional<String> previousProjectName) {
 
-        Project project = engagementService.createEngagement(engagement, author, authorEmail, newCustomerName, newProjectName);
+        Project project = engagementService.createEngagement(engagement, author, authorEmail, previousCustomerName,
+                previousProjectName);
 
         UriBuilder builder = uriInfo.getAbsolutePathBuilder();
         builder.path(Integer.toString(project.getId()));
@@ -60,67 +62,72 @@ public class EngagementResource {
     @Counted(name = "get-all-engagement", description = "Count of get all engagements")
     @Timed(name = "performedEngagementGetAll", description = "Time to get all engagements", unit = MetricUnits.MILLISECONDS)
     public Response findAllEngagements() {
-        
+
         List<Engagement> engagements = engagementService.getAllEngagements();
         return Response.ok().entity(engagements).build();
     }
-    
+
     @GET
     @Path("/namespace/{namespace}")
     @Counted(name = "get-engagement-namespace", description = "Count of get by id or namespace")
     @Timed(name = "performedEngagementGetByNamespace", description = "Time to get an engagement by namespace", unit = MetricUnits.MILLISECONDS)
-    public Response getEngagement(@PathParam("namespace") String namespace, @QueryParam("includeStatus") boolean includeStatus) {
+    public Response getEngagement(@PathParam("namespace") String namespace,
+            @QueryParam("includeStatus") boolean includeStatus) {
 
         Engagement response = engagementService.getEngagement(namespace, includeStatus);
         return Response.ok().entity(response).build();
     }
-    
+
     @GET
     @Path("/customer/{customer}/{engagement}")
     @Counted(name = "get-engagement", description = "Count of get engagement")
     @Timed(name = "performedEngagementGet", description = "Time to get an engagement", unit = MetricUnits.MILLISECONDS)
-    public Response getEngagement(@PathParam("customer") String customer, @PathParam("engagement") String engagement, @QueryParam("includeStatus") boolean includeStatus) {
-        
+    public Response getEngagement(@PathParam("customer") String customer, @PathParam("engagement") String engagement,
+            @QueryParam("includeStatus") boolean includeStatus) {
+
         Engagement response = engagementService.getEngagement(customer, engagement, includeStatus);
         return Response.ok().entity(response).build();
     }
-    
+
     @POST
     @Path("customer/{customer}/{engagement}/hooks")
     @Counted(name = "create-engagement-hook", description = "Count of create-hook requestst")
     @Timed(name = "performedHookCreate", description = "Time to create hook", unit = MetricUnits.MILLISECONDS)
-    public Response createProjectHook(Hook hook, @PathParam("customer") String customer, @PathParam("engagement") String engagement) {
-        
+    public Response createProjectHook(Hook hook, @PathParam("customer") String customer,
+            @PathParam("engagement") String engagement) {
+
         Response response = engagementService.createHook(customer, engagement, hook);
         return response;
     }
-    
+
     @GET
     @Path("/customer/{customer}/{engagement}/commits")
     @Counted(name = "get-engagement-commits", description = "Count of get engagement commits")
     @Timed(name = "performedEngagementCommitsGet", description = "Time to get engagement commits", unit = MetricUnits.MILLISECONDS)
-    public Response getEngagementCommits(@PathParam("customer") String customer, @PathParam("engagement") String engagement) {
-        
+    public Response getEngagementCommits(@PathParam("customer") String customer,
+            @PathParam("engagement") String engagement) {
+
         List<Commit> commitList = engagementService.getCommitLog(customer, engagement);
         return Response.ok().entity(commitList).build();
     }
-    
+
     @GET
     @Path("customer/{customer}/{engagement}/hooks")
     @Counted(name = "get-hook", description = "Count of get-hook requests")
     @Timed(name = "performedHookGetAll", description = "Time to get all hooks", unit = MetricUnits.MILLISECONDS)
-    public Response findAllProjectHooks(@PathParam("customer") String customer, @PathParam("engagement") String engagement) {
-        
+    public Response findAllProjectHooks(@PathParam("customer") String customer,
+            @PathParam("engagement") String engagement) {
+
         List<Hook> engagements = engagementService.getHooks(customer, engagement);
         return Response.ok().entity(engagements).build();
     }
-    
+
     @GET
     @Path("customer/{customer}/{engagement}/status")
     @Counted(name = "get-status", description = "Count of get-status requests")
     @Timed(name = "performedStatusGet", description = "Time to get status", unit = MetricUnits.MILLISECONDS)
     public Response getStatus(@PathParam("customer") String customer, @PathParam("engagement") String engagement) {
-        
+
         Status status = engagementService.getProjectStatus(customer, engagement);
         return Response.ok().entity(status).build();
     }

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -1,6 +1,7 @@
 package com.redhat.labs.lodestar.resource;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotBlank;
@@ -44,9 +45,10 @@ public class EngagementResource {
     @Counted(name = "engagement", description = "How many engagements request have been requested")
     @Timed(name = "performedCreates", description = "How much time it takes to create an engagement", unit = MetricUnits.MILLISECONDS)
     public Response createEngagement(Engagement engagement, @Context UriInfo uriInfo,
-            @NotBlank @QueryParam("username") String author, @NotBlank @QueryParam("userEmail") String authorEmail) {
+            @NotBlank @QueryParam("username") String author, @NotBlank @QueryParam("userEmail") String authorEmail,
+            @QueryParam("newCustomerName") Optional<String> newCustomerName, @QueryParam("newProjectName") Optional<String> newProjectName) {
 
-        Project project = engagementService.createEngagement(engagement, author, authorEmail);
+        Project project = engagementService.createEngagement(engagement, author, authorEmail, newCustomerName, newProjectName);
 
         UriBuilder builder = uriInfo.getAbsolutePathBuilder();
         builder.path(Integer.toString(project.getId()));

--- a/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -29,7 +30,7 @@ class EngagementServiceTest {
     @Test void testCreateEngagementUpdateProject() {
         
         Engagement e = Engagement.builder().customerName("updated").projectName("updated2").build();
-        Project project = engagementService.createEngagement(e, "Test Banana", "test@test.com");
+        Project project = engagementService.createEngagement(e, "Test Banana", "test@test.com", Optional.empty(), Optional.empty());
         assertFalse(project.isFirst());
             
     }
@@ -38,7 +39,7 @@ class EngagementServiceTest {
         
         Engagement e = Engagement.builder().customerName("customer").projectName("project").build();
         Exception exception = assertThrows(UnexpectedGitLabResponseException.class, () -> {
-            engagementService.createEngagement(e, "Test Banana", "test@test.com");
+            engagementService.createEngagement(e, "Test Banana", "test@test.com", Optional.empty(), Optional.empty());
         });
         
         assertEquals("failed to create group", exception.getMessage());
@@ -55,7 +56,7 @@ class EngagementServiceTest {
         
         Engagement e = Engagement.builder().customerName("project1").projectName("project1").build();
         Exception exception = assertThrows(UnexpectedGitLabResponseException.class, () -> {
-            engagementService.createEngagement(e, "Test Banana", "fail@commitmultiplefiles.com");
+            engagementService.createEngagement(e, "Test Banana", "fail@commitmultiplefiles.com", Optional.empty(), Optional.empty());
         });
 
         assertEquals("failed to commit files for engagement creation.", exception.getMessage());


### PR DESCRIPTION
If query parameters `previousCustomerName` or `previousProjectName` are provided, the corresponding group name will be changed in GitLab using the current values of `customerName` and `projectName` on the POSTed `engagement`. 