### PR TITLE
filter commits 🗄️ 🗄️ 🗄️ 🗄️ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Deployment template will read from the above secret and inject following env var
 
 | Name | Example Value | Required |
 |------|---------------|----------|
-| OMMIT_FILTERED_EMAIL_LIST | bot@bot.com,tob@tob.com | False |
+| COMMIT_FILTERED_EMAIL_LIST | bot@bot.com,tob@tob.com | False |
 
 ### Config Resource 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Deployment template will read from the above secret and inject following env var
 | GITLAB_API_URL | https://acmegit.com | True |
 | DEPLOY_KEY | 0 | True |
 
-### COMMITS
+### Commits
 
 | Name | Example Value | Required |
 |------|---------------|----------|

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Deployment template will read from the above secret and inject following env var
 | GITLAB_API_URL | https://acmegit.com | True |
 | DEPLOY_KEY | 0 | True |
 
+### COMMITS
+
+| Name | Example Value | Required |
+|------|---------------|----------|
+| OMMIT_FILTERED_EMAIL_LIST | bot@bot.com,tob@tob.com | False |
+
 ### Config Resource 
 
 | Name | Example Value | Required |

--- a/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
@@ -2,6 +2,7 @@ package com.redhat.labs.lodestar.service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -33,6 +34,9 @@ public class ProjectService {
     
     @ConfigProperty(name = "commit.page.size")
     int commitPageSize;
+    
+    @ConfigProperty(name = "commit.filter.list")
+    List<String> commitFilteredEmails;
 
     // get a project - this could be a replaced by a direct call to the project via the path
     // but must consider changes to the path for special characters
@@ -142,7 +146,7 @@ public class ProjectService {
         
         LOGGER.debug("total commits for project {} {}", projectId, page.size());
           
-        return page.getResults();
+        return page.getResults().stream().filter(e -> !commitFilteredEmails.contains(e.getAuthorEmail())).collect(Collectors.toList());
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ webhook.file=${WEBHOOK_FILE:/runtime/webhooks.yaml}
 webhook.default.token=${WEBHOOK_DEFAULT_TOKEN:tolkien}
 config.gitlab.ref=${CONFIG_GITLAB_REF:master}
 commit.page.size=100
+commit.filter.list=${COMMIT_FILTERED_EMAIL_LIST:bot@bot.com}
 
 # engagements
 engagements.repository.id=${ENGAGEMENTS_REPOSITORY_ID:2}

--- a/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/EngagementResourceTest.java
@@ -37,7 +37,7 @@ class EngagementResourceTest {
     }
     
     @Test
-    void tesetGetEngagementByNamespace() {
+    void testGetEngagementByNamespace() {
         given()
             .pathParam("namespace", "top/dog/jello/tutti-frutti/iac")
             .when()
@@ -164,9 +164,7 @@ class EngagementResourceTest {
                 .get("/api/v1/engagements/customer/jello/lemon/commits")
             .then()
                 .statusCode(200)
-                .body(is("[{\"author_email\":\"bot@bot.com\",\"author_name\":\"bot\",\"authored_date\":\"2020-06-16T00:12:27.000+00:00\",\"committed_date\":\"2020-06-16T00:12:27.000+00:00\",\"id\":\"551eefc6e367aa2ad3c56bdd7229c7bc525d4f0c\","
-                        + "\"message\":\"Auto-update generated files\",\"short_id\":\"551eefc6\",\"title\":\"Auto-update generated files\",\"web_url\":\"https://gitlab.example.com/store/jello/lemon/iac/-/commit/551eefc6e367aa2ad3c56bdd7229c7bc525d4f0c\"},"
-                        + "{\"author_email\":\"mmarner@example.com\",\"author_name\":\"Mitch Marner\",\"authored_date\":\"2020-06-16T00:12:18.000+00:00\",\"committed_date\":\"2020-06-16T00:12:18.000+00:00\","
+                .body(is("[{\"author_email\":\"mmarner@example.com\",\"author_name\":\"Mitch Marner\",\"authored_date\":\"2020-06-16T00:12:18.000+00:00\",\"committed_date\":\"2020-06-16T00:12:18.000+00:00\","
                         + "\"id\":\"5178ffab3566ac591af95c3383d1c5916de4a3a9\",\"message\":\"Update engagement.json\",\"short_id\":\"5178ffab\",\"title\":\"Update engagement.json\","
                         + "\"web_url\":\"https://gitlab.example.com/store/jello/lemon/iac/-/commit/5178ffab3566ac591af95c3383d1c5916de4a3a9\"},{\"author_email\":\"jtavares@example.com\",\"author_name\":\"John Tavares\","
                         + "\"authored_date\":\"2020-06-11T16:46:19.000+00:00\",\"committed_date\":\"2020-06-11T16:46:19.000+00:00\",\"id\":\"7865570dc63b1463d9fb4d02bd09ff46d244e694\",\"message\":\"Update status.json\","

--- a/src/test/java/com/redhat/labs/lodestar/service/ProjectServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/ProjectServiceTest.java
@@ -101,7 +101,7 @@ class ProjectServiceTest {
     @Test void getCommitsMultiPage() {
         List<Commit> commits = projectService.getCommitLog("multi/page/iac");
         assertNotNull(commits);
-        assertEquals(8, commits.size());
+        assertEquals(6, commits.size());
         
     }
 }


### PR DESCRIPTION
Gives ability to filter a list of emails from the commit log. 🗄️ 
* Commits will still be retrieved from gitlab
* Filtered in git-api and never stored
* Requests can not view commits from the filtered list

The email list can be configured with the config param COMMIT_FILTERED_EMAIL_LIST
* by default this list contains the absolutely not made up value of `bot@bot.com` 🤖 

In the test env the network load went from 16MB to 420k