### PR TITLE
allow hooks to be updated after archive if needed

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/models/ConfigMap.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/ConfigMap.java
@@ -8,6 +8,9 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ConfigMap {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigMap.class);
 
     private Path path;
     private String filePath;
@@ -43,6 +47,7 @@ public class ConfigMap {
                 content = Optional.of(new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
                 return true;
             } catch (IOException e) {
+                LOGGER.error("Error updating mounted file %{} {} {} ", lastModifiedTime, path, filePath);
                 content = Optional.empty();
             }
 
@@ -68,6 +73,7 @@ public class ConfigMap {
                 return true;
             }
         } catch (IOException e) {
+            LOGGER.error("Error calculating isModified %{} {}", lastModifiedTime, path);
             return false;
         }
 

--- a/src/main/java/com/redhat/labs/lodestar/models/gitlab/HookConfig.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/gitlab/HookConfig.java
@@ -26,5 +26,11 @@ public class HookConfig {
     
     @JsonbProperty("token")
     private String token;
+    
+    /**
+     * Should the webhook be enabled after an engagement is archived
+     */
+    @JsonbProperty("enabledAfterArchive")
+    private boolean enabledAfterArchive;
 
 }

--- a/src/test/java/com/redhat/labs/lodestar/mocks/MockGitLabService.java
+++ b/src/test/java/com/redhat/labs/lodestar/mocks/MockGitLabService.java
@@ -294,7 +294,7 @@ public class MockGitLabService implements GitLabService {
             return Response.status(Status.CREATED).build();
         }
         
-        return null;
+        return Response.status(Status.INTERNAL_SERVER_ERROR).build();
     }
 
     @Override

--- a/src/test/java/com/redhat/labs/lodestar/model/ProjectTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/model/ProjectTest.java
@@ -1,0 +1,32 @@
+package com.redhat.labs.lodestar.model;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.labs.lodestar.models.gitlab.Project;
+
+class ProjectTest {
+
+    @Test
+    void testPreserve() {
+
+        Project project = new Project();
+        Assertions.assertNull(project.getTagList());
+        
+        project.setTagList(new ArrayList<>());
+        Assertions.assertEquals(0, project.getTagList().size());
+
+        project.preserve();
+
+        Assertions.assertEquals(1, project.getTagList().size());
+        Assertions.assertEquals("DO_NOT_DELETE", project.getTagList().get(0));
+        
+        //Handle 2nd call properly
+        project.preserve();
+
+        Assertions.assertEquals(1, project.getTagList().size());
+        Assertions.assertEquals("DO_NOT_DELETE", project.getTagList().get(0));
+    }
+}

--- a/src/test/java/com/redhat/labs/lodestar/resource/ConfigResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/ConfigResourceTest.java
@@ -122,6 +122,7 @@ class ConfigResourceTest {
             .body(is("\n[\n" + 
                     "    {\n" + 
                     "        \"baseUrl\": \"https://labs.com/webhooks/\",\n" + 
+                    "        \"enabledAfterArchive\": false,\n" +
                     "        \"name\": \"labs\",\n" + 
                     "        \"pushEvent\": true,\n" + 
                     "        \"pushEventsBranchFilter\": \"master\",\n" + 
@@ -129,6 +130,7 @@ class ConfigResourceTest {
                     "    },\n" + 
                     "    {\n" + 
                     "        \"baseUrl\": \"https://rht.com/hooks/\",\n" + 
+                    "        \"enabledAfterArchive\": true,\n" +
                     "        \"name\": \"rht\",\n" + 
                     "        \"pushEvent\": true,\n" + 
                     "        \"pushEventsBranchFilter\": \"master\",\n" + 

--- a/src/test/resources/webhooks.yaml
+++ b/src/test/resources/webhooks.yaml
@@ -9,3 +9,4 @@
   pushEvent: true
   pushEventsBranchFilter: master
   token: def
+  enabledAfterArchive: true


### PR DESCRIPTION
An issue (715) was discovered that prevented webhooks from being updated on additional archived projects are not getting those hooks. This patches checks if a hook requires updating when archived and then adds it.