### PR TITLE
BugFix: Delete Engagement Cannot Find Project

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -189,7 +189,7 @@ public class EngagementService {
     }
 
     public Optional<Project> getProject(String customerName, String engagementName) {
-        String fullPath = GitLabPathUtils.getPath(engagementPathPrefix, customerName, engagementName);
+        String fullPath = GitLabPathUtils.getValidPath(engagementPathPrefix, customerName, engagementName);
 
         LOGGER.debug("Full path {}", fullPath);
         return projectService.getProjectByIdOrPath(fullPath);

--- a/src/main/java/com/redhat/labs/lodestar/service/ProjectStructureService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ProjectStructureService.java
@@ -295,10 +295,7 @@ public class ProjectStructureService {
 
     Optional<Project> findProjectByPath(String engagementPathPrefix, String customerName, String projectName) {
 
-        String customerPath = GitLabPathUtils.generateValidPath(customerName);
-        String projectPath = GitLabPathUtils.generateValidPath(projectName);
-        String fullPath = GitLabPathUtils.getPath(engagementPathPrefix, customerPath, projectPath);
-
+        String fullPath = GitLabPathUtils.getValidPath(engagementPathPrefix, customerName, projectName);
         return projectService.getProjectByIdOrPath(fullPath);
 
     }

--- a/src/main/java/com/redhat/labs/lodestar/utils/GitLabPathUtils.java
+++ b/src/main/java/com/redhat/labs/lodestar/utils/GitLabPathUtils.java
@@ -50,4 +50,12 @@ public class GitLabPathUtils {
                 .append("/iac").toString();
     }
 
+    public static String getValidPath(String engagementPathPrefix, String customerName, String engagementName) {
+
+        String customerPath = GitLabPathUtils.generateValidPath(customerName);
+        String projectPath = GitLabPathUtils.generateValidPath(engagementName);
+        return GitLabPathUtils.getPath(engagementPathPrefix, customerPath, projectPath);
+
+    }
+
 }


### PR DESCRIPTION
This PR fixes the issue where the engagement cannot be found because it was using the customer/engagement names as supplied to lookup a project.

This works if the names do not contain whitespace or special characters.  This fix uses the names and generates the path to the project allowing for the project to be found and then deleted.