### PR TITLE
Reduce Exception Logging For Status Not Found

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -157,8 +157,11 @@ public class EngagementResource {
     @Timed(name = "performedStatusGet", description = "Time to get status", unit = MetricUnits.MILLISECONDS)
     public Response getStatus(@PathParam("customer") String customer, @PathParam("engagement") String engagement) {
 
-        Status status = engagementService.getProjectStatus(customer, engagement);
-        return Response.ok().entity(status).build();
+        Optional<Status> status = engagementService.getProjectStatus(customer, engagement);
+        if(status.isPresent()) {
+            return Response.ok().entity(status).build(); 
+        }
+        return Response.status(404).build();
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -12,7 +12,6 @@ import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -191,7 +190,7 @@ public class EngagementService {
         return status;
     }
 
-    public Status getProjectStatus(String customerName, String engagementName) {
+    public Optional<Status> getProjectStatus(String customerName, String engagementName) {
 
         List<ProjectTreeNode> nodes = projectService
                 .getProjectTree(GitLabPathUtils.getValidPath(engagementPathPrefix, customerName, engagementName));
@@ -200,11 +199,11 @@ public class EngagementService {
         List<ProjectTreeNode> status = nodes.stream().filter(node -> STATUS_FILE.equals(node.getName()))
                 .collect(Collectors.toList());
         if (status.isEmpty()) {
-            throw new WebApplicationException("failed to find status.json", 404);
+            return Optional.empty();
         }
 
         // get status
-        return getProjectStatusFile(customerName, engagementName);
+        return Optional.of(getProjectStatusFile(customerName, engagementName));
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/EngagementServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.BDDMockito.given;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
@@ -23,6 +24,7 @@ import org.mockito.Mockito;
 
 import com.redhat.labs.lodestar.exception.UnexpectedGitLabResponseException;
 import com.redhat.labs.lodestar.models.Engagement;
+import com.redhat.labs.lodestar.models.Status;
 import com.redhat.labs.lodestar.models.gitlab.Group;
 import com.redhat.labs.lodestar.models.gitlab.Hook;
 import com.redhat.labs.lodestar.models.gitlab.Project;
@@ -191,12 +193,9 @@ class EngagementServiceTest {
         given(gitLabService.getProjectTree(Mockito.anyString(), Mockito.anyBoolean())).willReturn(r);
         given(gitLabService.getFile(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).willReturn(null);
 
-        WebApplicationException exception = assertThrows(WebApplicationException.class, () -> {
-            engagementService.getProjectStatus("nope", "nada");
-        });
+        Optional<Status> status = engagementService.getProjectStatus("nope", "nada");
 
-        assertEquals(404, exception.getResponse().getStatus());
-        assertEquals("failed to find status.json", exception.getMessage());
+        assertTrue(status.isEmpty());
 
     }
 


### PR DESCRIPTION
- just returning 404 Response from `GET /engagements/{customer}/{engagement}/status` instead of throwing uncaught WebApplicationException with a 404.
- This was causing a lot of stack traces in the logs when a db refresh was being performed from the backend.