### PR TITLE
Filter Commits for Manual Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Deployment template will read from the above secret and inject following env var
 | Name | Example Value | Required |
 |------|---------------|----------|
 | COMMIT_FILTERED_EMAIL_LIST | bot@bot.com,tob@tob.com | False |
+| COMMIT_FILTERED_MESSAGE_LIST | manual_refresh,another-message | False |
 
 ### Config Resource 
 

--- a/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
@@ -182,7 +182,7 @@ public class ProjectService {
         LOGGER.debug("total commits for project {} {}", projectId, page.size());
 
         return page.getResults().stream().filter(e -> !commitFilteredEmails.contains(e.getAuthorEmail()))
-                .collect(Collectors.toList());
+                .filter(e -> "manual_refresh".equals(e.getMessage())).collect(Collectors.toList());
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
@@ -182,7 +182,7 @@ public class ProjectService {
         LOGGER.debug("total commits for project {} {}", projectId, page.size());
 
         return page.getResults().stream().filter(e -> !commitFilteredEmails.contains(e.getAuthorEmail()))
-                .filter(e -> "manual_refresh".equals(e.getMessage())).collect(Collectors.toList());
+                .filter(e -> !"manual_refresh".equals(e.getMessage())).collect(Collectors.toList());
 
     }
 

--- a/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
@@ -47,6 +47,9 @@ public class ProjectService {
     @ConfigProperty(name = "commit.page.size")
     int commitPageSize;
 
+    @ConfigProperty(name = "commit.msg.filter.list")
+    List<String> commitFilteredMessages;
+
     @ConfigProperty(name = "commit.filter.list")
     List<String> commitFilteredEmails;
 
@@ -182,7 +185,7 @@ public class ProjectService {
         LOGGER.debug("total commits for project {} {}", projectId, page.size());
 
         return page.getResults().stream().filter(e -> !commitFilteredEmails.contains(e.getAuthorEmail()))
-                .filter(e -> !"manual_refresh".equals(e.getMessage())).collect(Collectors.toList());
+                .filter(e -> !commitFilteredMessages.contains(e.getMessage())).collect(Collectors.toList());
 
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ webhook.file=${WEBHOOK_FILE:/runtime/webhooks.yaml}
 webhook.default.token=${WEBHOOK_DEFAULT_TOKEN:tolkien}
 config.gitlab.ref=${CONFIG_GITLAB_REF:master}
 commit.page.size=100
+commit.msg.filter.list=${COMMIT_FILTERED_MESSAGE_LIST:manual_refresh}
 commit.filter.list=${COMMIT_FILTERED_EMAIL_LIST:bot@bot.com}
 config.reload=${CONFIG_RELOAD:false}
 

--- a/src/test/java/com/redhat/labs/lodestar/mocks/MockGitLabService.java
+++ b/src/test/java/com/redhat/labs/lodestar/mocks/MockGitLabService.java
@@ -346,6 +346,12 @@ public class MockGitLabService implements GitLabService {
         if("multi/page/missingheader".equals(projectId)) {
             return Response.ok(commitList).build();
         }
+
+        if("multi/page/filtered".equals(projectId)) {
+            Commit c = Commit.builder().message("manual_refresh").build();
+            commitList.add(c);
+            return Response.ok(commitList).build();
+        }
         
         return Response.ok(new ArrayList<Commit>()).header("X-Total-Pages", 0).build();
     }

--- a/src/test/java/com/redhat/labs/lodestar/service/ProjectServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/ProjectServiceTest.java
@@ -111,4 +111,11 @@ class ProjectServiceTest {
         assertNotNull(commits);
         assertEquals(3, commits.size());
     }
+
+    @Test void getCommitsMessageFilter() {
+        List<Commit> commits = projectService.getCommitLog("multi/page/filtered");
+        assertNotNull(commits);
+        assertEquals(3, commits.size());
+
+    }
 }


### PR DESCRIPTION
- added filter to GET commit log.  
- any commit message that matches a value in the configured filtered list, will be excluded from the response.
  - default configured message is `manual_refresh`
  - can be configured by environment variable `COMMIT_FILTERED_MESSAGE_LIST`