### PR TITLE
Commit Log Should Return Manual Refresh Commits With Scrubbed Commit Message

### DIFF
--- a/src/test/java/com/redhat/labs/lodestar/mocks/MockGitLabService.java
+++ b/src/test/java/com/redhat/labs/lodestar/mocks/MockGitLabService.java
@@ -348,8 +348,10 @@ public class MockGitLabService implements GitLabService {
         }
 
         if("multi/page/filtered".equals(projectId)) {
-            Commit c = Commit.builder().message("manual_refresh").build();
-            commitList.add(c);
+            Commit c1 = Commit.builder().message("manual_refresh").build();
+            commitList.add(c1);
+            Commit c2 = Commit.builder().message("manual_refresh some other text").build();
+            commitList.add(c2);
             return Response.ok(commitList).build();
         }
         

--- a/src/test/java/com/redhat/labs/lodestar/service/ProjectServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/ProjectServiceTest.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.redhat.labs.lodestar.mocks.MockGitLabService;
 import com.redhat.labs.lodestar.models.gitlab.Commit;
@@ -97,25 +99,15 @@ class ProjectServiceTest {
         projectService.deleteProject(45);
         assertNotNull(projectService);
     }
-    
-    @Test void getCommitsMultiPage() {
-        List<Commit> commits = projectService.getCommitLog("multi/page/iac");
-        assertNotNull(commits);
-        assertEquals(6, commits.size());
-        
-    }
 
-    //Will only get first page since the page size will be larger
-    @Test void getCommitsMultiPageMissingHeader() {
-        List<Commit> commits = projectService.getCommitLog("multi/page/missingheader");
-        assertNotNull(commits);
-        assertEquals(3, commits.size());
-    }
+    @ParameterizedTest
+    @CsvSource({"multi/page/iac,6", "multi/page/missingheader,3", "multi/page/filtered,4"})
+    void getCommitLog(String project, Integer expectedCommitSize) {
 
-    @Test void getCommitsMessageFilter() {
-        List<Commit> commits = projectService.getCommitLog("multi/page/filtered");
+        List<Commit> commits = projectService.getCommitLog(project);
         assertNotNull(commits);
-        assertEquals(3, commits.size());
+        assertEquals(expectedCommitSize, commits.size());
 
     }
+
 }


### PR DESCRIPTION
The `manual_refresh` can be used to trigger a refresh for the given engagement.

If the commit message only contains `manual_refresh`, the commit will not be returned as part of the GET API for commits.

If the commit message contains a message after `manual_refesh`, the commit will be returned with `manual_refresh` stripped out from the commit message.