### PR TITLE
Response Mapper for WebApplicationExceptions

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/exception/mapper/GitApiExceptionHandler.java
+++ b/src/main/java/com/redhat/labs/lodestar/exception/mapper/GitApiExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.redhat.labs.lodestar.exception.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class GitApiExceptionHandler implements ExceptionMapper<WebApplicationException> {
+
+    @Override
+    public Response toResponse(WebApplicationException exception) {
+
+        Map<String, String> map = new HashMap<>();
+        map.put("message", exception.getMessage());
+
+        return Response.status(exception.getResponse().getStatus()).entity(map).build();
+
+    }
+
+}


### PR DESCRIPTION
Created Exception Handler to map WebApplicationExceptions to Responses so that the stack traces are not printed in the logs for expected thrown exceptions.