### PR TITLE
New attributes for Engagement Nested Objects

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/models/Artifact.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/Artifact.java
@@ -1,17 +1,18 @@
 package com.redhat.labs.lodestar.models;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Artifact {
+@EqualsAndHashCode(callSuper = true)
+public class Artifact extends EngagementAttribute {
 
-    private String id;
     private String title;
     private String description;
     private String type;

--- a/src/main/java/com/redhat/labs/lodestar/models/Category.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/Category.java
@@ -1,15 +1,17 @@
 package com.redhat.labs.lodestar.models;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Category {
+@EqualsAndHashCode(callSuper = true)
+public class Category extends EngagementAttribute {
 
     private String name;
     private Integer count;

--- a/src/main/java/com/redhat/labs/lodestar/models/Engagement.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/Engagement.java
@@ -1,7 +1,6 @@
 package com.redhat.labs.lodestar.models;
 
 import java.util.List;
-import java.util.Map;
 
 import javax.json.bind.annotation.JsonbProperty;
 
@@ -55,6 +54,6 @@ public class Engagement {
     private List<Artifact> artifacts;
     private String commitMessage;
     private List<UseCase> useCases;
-    private Map<String, Double> scores;
+    private List<Score> scores;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/models/EngagementAttribute.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/EngagementAttribute.java
@@ -2,7 +2,6 @@ package com.redhat.labs.lodestar.models;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
@@ -10,11 +9,11 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class UseCase extends EngagementAttribute {
+public class EngagementAttribute {
 
-    private String title;
-    private String description;
-    private Integer order;
+    private String uuid;
+    private String created;
+    private String updated;
+    private String engagementUuid;
 
 }

--- a/src/main/java/com/redhat/labs/lodestar/models/HostingEnvironment.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/HostingEnvironment.java
@@ -1,16 +1,17 @@
 package com.redhat.labs.lodestar.models;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class HostingEnvironment {
-    private String id;
+@EqualsAndHashCode(callSuper = true)
+public class HostingEnvironment extends EngagementAttribute {
 
     private String additionalDetails;
 

--- a/src/main/java/com/redhat/labs/lodestar/models/Score.java
+++ b/src/main/java/com/redhat/labs/lodestar/models/Score.java
@@ -11,10 +11,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class UseCase extends EngagementAttribute {
+public class Score extends EngagementAttribute {
 
-    private String title;
-    private String description;
-    private Integer order;
+    private String name;
+    private Double value;
 
 }


### PR DESCRIPTION
- added `uuid`, `created`, and `updated` to artifacts, categories, use cases, scores, and hosting environments
- created object for scores instead of Map.  allows the attributes above to be set.