### PR TITLE
Only look for the status.json at root

### DIFF
--- a/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/EngagementService.java
@@ -193,7 +193,7 @@ public class EngagementService {
     public Optional<Status> getProjectStatus(String customerName, String engagementName) {
 
         List<ProjectTreeNode> nodes = projectService
-                .getProjectTree(GitLabPathUtils.getValidPath(engagementPathPrefix, customerName, engagementName));
+                .getProjectTree(GitLabPathUtils.getValidPath(engagementPathPrefix, customerName, engagementName), false);
 
         // find status file node or throw 404
         List<ProjectTreeNode> status = nodes.stream().filter(node -> STATUS_FILE.equals(node.getName()))

--- a/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/ProjectService.java
@@ -205,13 +205,13 @@ public class ProjectService {
 
     }
 
-    public List<ProjectTreeNode> getProjectTree(String projectId) {
+    public List<ProjectTreeNode> getProjectTree(String projectId, boolean recursive) {
 
         Response response = null;
         PagedResults<ProjectTreeNode> page = new PagedResults<>(commitPageSize);
 
         while (page.hasMore()) {
-            response = gitLabService.getProjectTree(projectId, true);
+            response = gitLabService.getProjectTree(projectId, recursive);
             page.update(response, new GenericType<List<ProjectTreeNode>>() {
             });
         }


### PR DESCRIPTION
When running recursively in the gitlab api the status.json doesn't always get returned when it should. Only looking at the top level folder seems more reliable