### PR TITLE
Migrate engagements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<quarkus-plugin.version>1.11.3.Final</quarkus-plugin.version>
+		<quarkus-plugin.version>1.13.7.Final</quarkus-plugin.version>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-		<quarkus.platform.version>1.11.3.Final</quarkus.platform.version>
+		<quarkus.platform.version>1.13.7.Final</quarkus.platform.version>
 		<surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
 		<lombok.version>1.18.12</lombok.version>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/EngagementResource.java
@@ -88,7 +88,7 @@ public class EngagementResource {
                     includeCommits);
             builder.entity(ePage.getEngagements());
             builder.links(ePage.getLinks(uriInfo.getAbsolutePathBuilder()));
-            ePage.getHeaders().entrySet().stream().forEach(e -> builder.header(e.getKey(), e.getValue()));
+            ePage.getHeaders().entrySet().forEach(e -> builder.header(e.getKey(), e.getValue()));
 
         } else {
             builder.entity(engagementService.getAllEngagements(includeStatus, includeCommits));

--- a/src/main/java/com/redhat/labs/lodestar/resource/MigrationResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/MigrationResource.java
@@ -3,6 +3,7 @@ package com.redhat.labs.lodestar.resource;
 import javax.inject.Inject;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
@@ -11,26 +12,37 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.redhat.labs.lodestar.service.MigrationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 @Path("/api/migrate")
 @Tag(name = "Migration", description = "Migration services")
 public class MigrationResource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationResource.class);
 
     @Inject
     MigrationService migrationService;
 
     @PUT
     @Timed(name = "performedMigration", description = "How much time it takes to migrate", unit = MetricUnits.MILLISECONDS)
+    @Produces("application/json")
     public Response migrate(@QueryParam(value = "participants") boolean migrateParticipants,
             @QueryParam("artifacts") boolean migrateArtifacts,
-            @QueryParam("uuids") boolean migrateUuids,
+            @QueryParam("projects") boolean migrateUuids,
             @QueryParam("hosting") boolean migrateHosting,
             @QueryParam("engagements") boolean migrateEngagements,
             @QueryParam("overwrite") boolean overwrite,
-            @QueryParam("uuid") String uuid) {
-        
-        migrationService.migrate(migrateUuids, migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements,
-                overwrite, uuid);
+            @QueryParam("uuids") List<String> uuids) {
+
+        try {
+            migrationService.migrate(migrateUuids, migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements,
+                    overwrite, uuids);
+        } catch (Exception ex) {
+            LOGGER.error("Migration did not complete successfully", ex);
+            return Response.status(Response.Status.BAD_REQUEST).entity("{ \"message\": \"Migration did not complete successfully\"}").build();
+        }
         
         return Response.ok().build();
 

--- a/src/main/java/com/redhat/labs/lodestar/resource/MigrationResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/MigrationResource.java
@@ -7,27 +7,30 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.redhat.labs.lodestar.service.MigrationService;
 
 @Path("/api/migrate")
-@Tag(name = "Migration", description = "Migratiion services")
+@Tag(name = "Migration", description = "Migration services")
 public class MigrationResource {
 
     @Inject
     MigrationService migrationService;
 
     @PUT
-    @Counted(name = "migration", description = "How many migation requests have been invoked")
     @Timed(name = "performedMigration", description = "How much time it takes to migrate", unit = MetricUnits.MILLISECONDS)
     public Response migrate(@QueryParam(value = "participants") boolean migrateParticipants,
-            @QueryParam(value = "artifacts") boolean migrateArtifacts,
-            @QueryParam(value = "uuids") boolean migrateUuids, @QueryParam(value = "hosting") boolean migrateHosting) {
+            @QueryParam("artifacts") boolean migrateArtifacts,
+            @QueryParam("uuids") boolean migrateUuids,
+            @QueryParam("hosting") boolean migrateHosting,
+            @QueryParam("engagements") boolean migrateEngagements,
+            @QueryParam("overwrite") boolean overwrite,
+            @QueryParam("uuid") String uuid) {
         
-        migrationService.migrate(migrateUuids, migrateParticipants, migrateArtifacts, migrateHosting);
+        migrationService.migrate(migrateUuids, migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements,
+                overwrite, uuid);
         
         return Response.ok().build();
 

--- a/src/main/java/com/redhat/labs/lodestar/service/FileService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/FileService.java
@@ -52,13 +52,11 @@ public class FileService {
     // create multiple files
     public boolean createFiles(Integer projectId, CommitMultiple commit) {
 
-        Response response = null;
-
         // encode actions in commit
         commit.encodeActions();
 
         // call gitlab api to commit
-        response = gitLabService.commitMultipleFiles(projectId, commit);
+        Response response = gitLabService.commitMultipleFiles(projectId, commit);
 
         // decode actions in commit
         commit.decodeActions();
@@ -105,7 +103,7 @@ public class FileService {
             // set branch
             file.setBranch(ref);
             // add commit message
-            file.setCommitMessage(String.format("git api deleted file. {}", filePath));
+            file.setCommitMessage(String.format("git api deleted file. %s", filePath));
 
             gitLabService.deleteFile(projectId, filePath, file);
         }

--- a/src/main/java/com/redhat/labs/lodestar/service/MigrationService.java
+++ b/src/main/java/com/redhat/labs/lodestar/service/MigrationService.java
@@ -58,9 +58,9 @@ public class MigrationService {
      * engagements that haven't been migrated. 
      */
     public void migrate(boolean migrateUuids, boolean migrateParticipants, boolean migrateArtifacts, boolean migrateHosting,
-                        boolean migrateEngagements, boolean overwrite, String uuid) {
+                        boolean migrateEngagements, boolean overwrite, List<String> uuids) {
         LOGGER.debug("uuids {} participants {} artifacts {} hosting {} engagements {} overwrite {} uuid {}", migrateUuids,
-                migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements, overwrite, uuid);
+                migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements, overwrite, uuids.size());
 
         getAllEngagements(); //hydrate before stream
 
@@ -71,16 +71,20 @@ public class MigrationService {
         }
 
         LOGGER.info("Start Migrate content");
-        migrateAll(migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements, overwrite, uuid);
+        migrateAll(migrateParticipants, migrateArtifacts, migrateHosting, migrateEngagements, overwrite, uuids);
         LOGGER.info("End Migrate content");
 
     }
 
     private void migrateAll(boolean migrateParticipants, boolean migrateArtifacts, boolean migrateHosting,
-                            boolean migrateEngagements, boolean overwrite, String uuid ) {
-        getAllEngagements().values().forEach(e -> {
-            LOGGER.debug("Migrating {}", e.getUuid());
-            if(uuid == null || e.getUuid().equals(uuid)) {
+                            boolean migrateEngagements, boolean overwrite, List<String> uuids ) {
+        int counter = 0;
+        for(Engagement e : getAllEngagements().values()) {
+
+            if(uuids.isEmpty() || uuids.contains(e.getUuid())) {
+                counter++;
+                LOGGER.debug("Migrating ({}) {}", counter, e.getUuid());
+                
                 List<Action> actions = new ArrayList<>();
                 String content;
                 if(migrateEngagements) {
@@ -112,7 +116,7 @@ public class MigrationService {
                     fileService.createFiles(e.getProjectId(), commit);
                 }
             }
-        });
+        }
     }
 
     /**

--- a/src/main/resources/META-INF/resources/index.html
+++ b/src/main/resources/META-INF/resources/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico"/>
-    <title>Lodestar Participants - 1.0.0-SNAPSHOT</title>
+    <title>Lodestar Git API- 1.0.0-SNAPSHOT</title>
     <style>
         h1, h2, h3, h4, h5, h6 {
             margin-bottom: 0.5rem;
@@ -110,7 +110,7 @@
 <body>
 
 <div class="banner lead">
-    LodeStar Participants API
+    LodeStar Git API
 </div>
 
 <div class="container">
@@ -128,7 +128,7 @@
             <h3>Application</h3>
             <ul>
                 <li>GroupId: <code>com.redhat.labs.lodestar</code></li>
-                <li>ArtifactId: <code>lodestar-participants</code></li>
+                <li>ArtifactId: <code>lodestar-git-api</code></li>
                 <li>Version: <code>1.0.0-SNAPSHOT</code></li>
                 <li>Quarkus Version: <code>1.13.7.Final</code></li>
             </ul>

--- a/src/test/java/com/redhat/labs/lodestar/service/MigrationServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/MigrationServiceTest.java
@@ -1,18 +1,18 @@
 package com.redhat.labs.lodestar.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import javax.inject.Inject;
 
+import com.redhat.labs.lodestar.models.*;
+import com.redhat.labs.lodestar.models.gitlab.CommitMultiple;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import com.redhat.labs.lodestar.models.Artifact;
-import com.redhat.labs.lodestar.models.Engagement;
-import com.redhat.labs.lodestar.models.EngagementUser;
 import com.redhat.labs.lodestar.models.gitlab.File;
 import com.redhat.labs.lodestar.models.gitlab.Project;
 
@@ -51,7 +51,17 @@ public class MigrationServiceTest {
 
         List<Engagement> allEngagements = new ArrayList<>();
 
-        Engagement e = Engagement.builder().uuid("a1").projectId(1).build();
+        List<Category> cats = new ArrayList<>();
+        cats.add(Category.builder().uuid("kittycat").name("As")
+                .created("2021-08-26T20:42:46.050483").updated("2021-08-26T20:42:46.050483").build());
+        cats.add(Category.builder().uuid("meow").name("Snowball").build());
+
+        List<UseCase> uses = new ArrayList<>();
+        uses.add(UseCase.builder().title("use case").created("2021-08-26T20:42:46.050483")
+                .updated("2021-08-26T20:42:46.050483").build());
+        uses.add(UseCase.builder().title("use case2").build());
+
+        Engagement e = Engagement.builder().uuid("a1").categories(cats).useCases(uses).projectId(1).build();
         allEngagements.add(e);
 
         e = Engagement.builder().uuid("c3").projectId(3).engagementUsers(engagementUsers).build();
@@ -76,16 +86,17 @@ public class MigrationServiceTest {
     
     @Test 
     void migrate() {
-        migrationService.migrate(false, false, false, false);
+        migrationService.migrate(false, false, false, false, false,
+                false, null);
         
         Mockito.verify(projectServiceMock, Mockito.never()).updateProject(Mockito.any());
         Mockito.verify(fileServiceMock, Mockito.never()).createFile(Mockito.anyInt(), Mockito.eq("engagement/participants.json"), Mockito.any(File.class));
 
-        migrationService.migrate(true, true, true, true);
+        migrationService.migrate(true, true, true, true, true, false, null);
 
         Mockito.verify(projectServiceMock, Mockito.times(2)).updateProject(Mockito.any());
-        Mockito.verify(fileServiceMock, Mockito.times(2)).createFile(Mockito.anyInt(), Mockito.eq("engagement/hosting.json"), Mockito.any(File.class));
-        Mockito.verify(fileServiceMock, Mockito.times(2)).createFile(Mockito.anyInt(), Mockito.eq("engagement/participants.json"), Mockito.any(File.class));
+        Mockito.verify(fileServiceMock, Mockito.times(3)).createFiles(Mockito.anyInt(), Mockito.any(CommitMultiple.class));
+        Mockito.verify(fileServiceMock, Mockito.never()).createFile(Mockito.anyInt(), Mockito.eq("engagement/participants.json"), Mockito.any(File.class));
     }
     
     

--- a/src/test/java/com/redhat/labs/lodestar/service/MigrationServiceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/service/MigrationServiceTest.java
@@ -87,12 +87,12 @@ public class MigrationServiceTest {
     @Test 
     void migrate() {
         migrationService.migrate(false, false, false, false, false,
-                false, null);
+                false, Collections.emptyList());
         
         Mockito.verify(projectServiceMock, Mockito.never()).updateProject(Mockito.any());
         Mockito.verify(fileServiceMock, Mockito.never()).createFile(Mockito.anyInt(), Mockito.eq("engagement/participants.json"), Mockito.any(File.class));
 
-        migrationService.migrate(true, true, true, true, true, false, null);
+        migrationService.migrate(true, true, true, true, true, false, Collections.emptyList());
 
         Mockito.verify(projectServiceMock, Mockito.times(2)).updateProject(Mockito.any());
         Mockito.verify(fileServiceMock, Mockito.times(3)).createFiles(Mockito.anyInt(), Mockito.any(CommitMultiple.class));


### PR DESCRIPTION
- Add support for migrating the migration summary portion of an engagement
- Combine migrations so only 1 commit happens per req / per engagement (previously would commit per new service).
- Add support for overriding the current data of the new services
- Add support for migrating only a list of uuids.

